### PR TITLE
fix(version): read installed package version

### DIFF
--- a/src/renamr/__init__.py
+++ b/src/renamr/__init__.py
@@ -1,3 +1,5 @@
 """renamr package."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version
+
+__version__ = version("renamr")

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -1,7 +1,9 @@
 """Integration smoke tests for the package scaffold."""
 
+from importlib.metadata import version
+
 from renamr import __version__
 
 
 def test_package_exposes_version() -> None:
-    assert __version__ == "0.1.0"
+    assert __version__ == version("renamr")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from importlib.metadata import version
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -20,7 +21,7 @@ def test_version_command_outputs_version() -> None:
     result = runner.invoke(app, ["version"])
 
     assert result.exit_code == 0
-    assert "0.1.0" in result.stdout
+    assert version("renamr") in result.stdout
 
 
 def test_init_creates_config_from_package_data(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## What changed
- read the package version from installed metadata instead of a stale hardcoded constant
- update CLI and integration tests to assert against installed package metadata

## Why
- `renamr version` reported `0.1.0` even after installing `1.0.0`
- package metadata was correct, but the CLI output was misleading

## Validation
- `nox`