### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog,
 and this project adheres to Semantic Versioning.
 
+## [1.0.1] - 2026-03-13
+
+
+
+### Fixed
+
+- **version:** Read installed package version
+
+
 ## [1.0.0] - 2026-03-12
 
 
@@ -12,6 +21,11 @@ and this project adheres to Semantic Versioning.
 ### Added
 
 - **cli:** Implement AI-powered file renaming workflow 
+
+
+### Maintenance
+
+- Release v1.0.0
 
 
 ## [0.1.0] - 2026-03-12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "renamr"
-version = "1.0.0"
+version = "1.0.1"
 description = "CLI tool that renames local files using AI-powered metadata extraction"
 authors = [
     { name = "Silas Pignotti", email = "pignottisilas@gmail.com" }


### PR DESCRIPTION
Version: `1.0.1`

- changelog generated with `git-cliff`
- validation performed: `nox` before release prep and `nox` after the release commit

After CI is green:
- squash merge in GitHub UI
- run `/release-finalize v1.0.1` after merge