### PR TITLE
fix(lockfile): prevent nox from mutating uv.lock

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,7 @@ def sync_project(session: nox.Session) -> None:
         "uv",
         "sync",
         "--all-groups",
+        "--locked",
         "--reinstall-package",
         PROJECT_NAME,
         external=True,

--- a/uv.lock
+++ b/uv.lock
@@ -1728,7 +1728,7 @@ wheels = [
 
 [[package]]
 name = "renamr"
-version = "0.1.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
## What changed
- added `--locked` to `uv sync` in `noxfile.py`
- updated the stale local package entry in `uv.lock` from `0.1.0` to `1.0.1`

## Why
`nox` was silently rewriting `uv.lock` because the committed lockfile was out of sync with `pyproject.toml`. That left the worktree dirty after routine checks and kept blocking branch and PR workflows.

## Validation
- `nox`
- confirmed `uv sync --locked --reinstall-package renamr` succeeds without further lockfile mutation