### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog,
 and this project adheres to Semantic Versioning.
 
+## [1.1.0] - 2026-03-13
+
+
+
+### Added
+
+- **cli:** Add global config and multi-inbox support
+
+
+### Fixed
+
+- Prevent nox from mutating lockfile
+
+
 ## [1.0.1] - 2026-03-13
 
 
@@ -12,6 +26,11 @@ and this project adheres to Semantic Versioning.
 ### Fixed
 
 - **version:** Read installed package version
+
+
+### Maintenance
+
+- Release v1.0.1
 
 
 ## [1.0.0] - 2026-03-12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "renamr"
-version = "1.0.1"
+version = "1.1.0"
 description = "CLI tool that renames local files using AI-powered metadata extraction"
 authors = [
     { name = "Silas Pignotti", email = "pignottisilas@gmail.com" }

--- a/uv.lock
+++ b/uv.lock
@@ -1714,7 +1714,7 @@ wheels = [
 
 [[package]]
 name = "renamr"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
## Release
- version: `1.1.0`
- changelog generated with `git-cliff`

## Validation
- `nox` passed on `main` before preparing the release branch
- `nox` passed again on `release/v1.1.0` after the release artifacts were committed

## Notes
- squash merge this PR in GitHub UI after CI is green
- after merge, run `/release-finalize v1.1.0`
