### PR TITLE
chore: migrate to opencode workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,3 @@ htmlcov/
 # Runtime data
 config.toml
 data/undo.json
-
-# Agent runtime artifacts
-.pi/plans/
-.pi/reviews/
-.pi/LESSONS.md

--- a/.opencode/LESSONS.md
+++ b/.opencode/LESSONS.md
@@ -1,0 +1,19 @@
+# Project Lessons
+
+Project-specific learnings for this repository. Run `/lessons` to curate entries, promote cross-project patterns to the global lessons file, and promote standing rules to `AGENTS.md`.
+
+Entry format: `- [YYYY-MM-DD] <what was tricky or wrong> → <correct approach>`
+
+---
+
+## Project Decisions
+
+<!-- one-off architectural choices, constraints, workarounds specific to this project -->
+
+## Tooling and Environment
+
+<!-- project-specific tool behavior, config quirks, environment setup gotchas -->
+
+## Recurring Issues
+
+<!-- patterns that keep coming up in this project — candidates for promotion to global lessons -->

--- a/.opencode/commands/oss-setup.md
+++ b/.opencode/commands/oss-setup.md
@@ -1,0 +1,24 @@
+---
+description: Apply OSS hardening to this Python project — CI, release workflow, cliff.toml, license, badges, branch protection
+agent: build
+---
+Apply the OSS hardening layer to this Python OSS repository.
+
+Load the local `python-oss-setup` skill and execute the full hardening flow.
+
+Guards — stop immediately if:
+- currently on `main` — create a feature branch first: `/git feature oss-setup`
+- `pyproject.toml` is missing — run `/python-init` first
+- `uv run nox` is not passing — fix the base setup before hardening
+
+The skill will:
+1. resolve author, year, and GitHub remote metadata
+2. create `LICENSE` (MIT), `.github/workflows/ci.yml`, `.github/workflows/release.yml`, `cliff.toml`
+3. insert CI and PyPI badges into `README.md`
+4. verify: `uv run nox` must pass
+5. commit all OSS hardening as one clean logical change
+6. apply branch protection via `gh api` (automated where `gh` is authenticated)
+7. report what was done and print the PyPI Trusted Publisher manual checklist
+
+Do not implement product features in this step.
+After this command completes, open a PR and merge it, then configure PyPI Trusted Publisher.

--- a/.opencode/commands/python-init.md
+++ b/.opencode/commands/python-init.md
@@ -1,0 +1,23 @@
+---
+description: Bootstrap this Python OSS project from PROJECT.md
+agent: build
+---
+Initialize this Python OSS project from `PROJECT.md`.
+
+Load the local `python-setup` skill and execute the full bootstrap process.
+
+Guards — stop immediately if:
+- `PROJECT.md` is missing in the current directory
+- the directory already has a `pyproject.toml`, `setup.py`, or initialized `src/` layout — suggest `/migrate` instead
+
+The skill will:
+1. read `PROJECT.md` and extract project name, type, framework, deps, secrets, and git remote
+2. initialize uv, create the package structure, install deps
+3. generate `pyproject.toml` (with full OSS packaging metadata), `noxfile.py` (with `ci` session), `.gitignore`, `README.md`, `AGENTS.md`
+4. write starter files and one passing smoke test
+5. initialize git, commit, and push to remote if configured
+6. verify: `OPENCODE_CONFIG=./opencode.json opencode --help >/dev/null` and `uv run nox` must be green
+
+Scaffold only — do not implement product logic from PROJECT.md.
+
+After this command completes, run `/oss-setup` to apply CI workflow, release workflow, changelog tooling, and license.

--- a/.opencode/commands/release.md
+++ b/.opencode/commands/release.md
@@ -1,0 +1,18 @@
+---
+description: Release this Python OSS project — version bump, changelog, tag, and push in one step
+agent: build
+---
+Release this Python OSS repository.
+
+Load the local `git-release` skill and execute the full release flow.
+
+Run this command from `main` after a feature PR has been merged and you are ready to publish a new version.
+
+The skill will:
+1. validate the repository state and tooling
+2. run the full `nox` validation gate
+3. inspect commit history since the last tag and suggest a version bump
+4. show you a preview and wait for your confirmation
+5. bump `pyproject.toml`, generate `CHANGELOG.md`, commit, tag, and push
+
+Do not run this from a feature branch. Do not run this with uncommitted changes.

--- a/.opencode/skills/git-release/SKILL.md
+++ b/.opencode/skills/git-release/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: git-release
+description: Prepare and publish a release for a Python OSS repository — version bump, changelog generation with git-cliff, commit, tag, and push in one command
+---
+## Purpose
+
+Use this skill to release a Python OSS repository.
+
+This skill is only for OSS repos. It is not appropriate for portfolio or tool repos.
+
+Run this skill via the `/release` command in `build` mode, after a feature PR has been merged to `main`.
+
+## Prerequisites
+
+Before running a release:
+- you are on `main` with a clean working tree
+- the PR for the feature has been merged
+- `nox` passes cleanly
+- `git-cliff` is installed (`brew install git-cliff`)
+- the GitHub Actions release workflow is configured (`.github/workflows/release.yml`)
+- PyPI Trusted Publisher is configured for this repo (one-time setup via `/oss-setup` checklist) — without this the release workflow will fail at the PyPI publish step
+
+## Release Flow
+
+```
+1. state guards
+2. tooling guards
+3. run nox — full validation gate
+3b. run security audit (pip-audit)
+4. inspect version and commit history
+5. suggest bump type and new version
+6. wait for user confirmation
+7. bump version in pyproject.toml
+8. generate CHANGELOG.md with git-cliff
+9. commit release artifacts
+10. tag vX.Y.Z
+11. push commit + tag
+12. report to user
+```
+
+## Detailed Steps
+
+### 1. State Guards
+
+```bash
+git branch --show-current   # must be main
+git status --short           # must be clean
+```
+
+If either fails: stop and explain why.
+
+### 2. Tooling Guards
+
+```bash
+git-cliff --version   # must be available
+```
+
+If not available: stop with install instruction: `brew install git-cliff`
+
+### 3. Full Validation
+
+```bash
+uv run nox
+```
+
+Must be green. Stop if any session fails.
+
+### 3b. Security Audit
+
+Run security checks before releasing to PyPI:
+
+```bash
+pip-audit --skip-editable
+```
+
+If vulnerabilities found:
+- **Critical/High**: Stop release, fix vulnerabilities first
+- **Medium/Low**: Warn user, ask for confirmation to proceed
+
+Optionally run SAST (if `nox -s security` is available):
+```bash
+nox -s security
+```
+
+### 4. Inspect Version and History
+
+Read current version from `pyproject.toml`:
+```bash
+rg '^version = ' pyproject.toml
+```
+
+Find the latest tag:
+```bash
+git tag --sort=-version:refname | head -1
+```
+
+**No prior tag (first release):**
+- state: "No prior release found. This will be your first release."
+- show the current version from `pyproject.toml` as the suggested version
+- ask the user to confirm
+
+**Prior tag exists:**
+- review commits since the latest tag:
+  ```bash
+  git log <latest-tag>..HEAD --oneline
+  ```
+- suggest bump type based on Conventional Commit history:
+  - any `!` or `BREAKING CHANGE` → major
+  - any `feat` → minor
+  - only `fix`, `refactor`, `docs`, `chore`, `ci`, `test` → patch
+- show the reasoning and the resulting version
+- ask the user to confirm
+
+### 5. Wait for Confirmation
+
+Do not modify any files until the user confirms the version. Show:
+- current version
+- suggested new version
+- bump type reasoning
+- preview of commits that will be in this release
+
+### 6. Bump Version
+
+Update `pyproject.toml`:
+- find `version = "X.Y.Z"` under `[project]`
+- replace with the confirmed new version
+- do not edit anything else in the file
+
+### 7. Generate Changelog
+
+```bash
+git-cliff --tag vX.Y.Z -o CHANGELOG.md
+```
+
+If `CHANGELOG.md` does not exist, `git-cliff` will create it. If it exists, it will be overwritten with the full history. This is correct — `git-cliff` regenerates from all tags every time.
+
+### 8. Commit Release Artifacts
+
+```bash
+git add pyproject.toml CHANGELOG.md
+git commit -m "chore: release vX.Y.Z"
+```
+
+Only stage `pyproject.toml` and `CHANGELOG.md`. Nothing else.
+
+### 9. Tag
+
+```bash
+git tag vX.Y.Z
+```
+
+Always use the `v` prefix. Never tag before the release commit is in place.
+
+### 10. Push Commit + Tag
+
+```bash
+git push origin main
+git push origin vX.Y.Z
+```
+
+Push the commit first, then the tag. The tag push triggers the GitHub Actions release workflow.
+
+Note: `git push origin main` works here because branch protection is configured with `enforce_admins: false` — the repo owner can push release commits directly to `main`. If this push is rejected, branch protection may have been set with admin enforcement enabled. Check GitHub → Settings → Branches → Edit rule for `main` and ensure "Include administrators" is unchecked.
+
+### 11. Report
+
+Tell the user:
+- release `vX.Y.Z` is tagged and pushed
+- GitHub Actions release workflow is now running
+- PyPI publish will follow if CI passes
+
+## Rules
+
+- release only from `main` with a clean working tree
+- release only after `nox` passes
+- run security audit (`pip-audit`) before every release
+- never tag before bumping and committing
+- never push the tag before pushing the commit
+- never hand-write changelog entries — always use `git-cliff`
+- tag format is always `vX.Y.Z`
+- only touch `pyproject.toml` and `CHANGELOG.md` in the release commit
+- never create a release PR — push directly to main
+
+## Don't
+
+- run this on portfolio or tool repos
+- run this from a feature branch
+- run this with uncommitted changes
+- create the tag before the release commit is pushed
+- skip the nox validation gate
+- skip the security audit
+- guess the version without showing commit history reasoning first

--- a/.opencode/skills/python-oss-setup/SKILL.md
+++ b/.opencode/skills/python-oss-setup/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: python-oss-setup
+description: Harden a Python OSS repository after python-setup — adds CI, release workflow, cliff.toml, license, badges, and automated branch protection
+---
+## Purpose
+
+Use this skill after `python-setup` has been applied and the base Python stack is working.
+
+This is the second-step hardening layer for public Python OSS projects only. Run it from a feature branch, not from `main` — the changes should go through a PR.
+
+Do not use this skill for portfolio or tool repositories.
+
+## Preconditions
+
+- `pyproject.toml` exists and `uv run nox` passes cleanly
+- git is initialized with at least one commit
+- a GitHub remote is configured (`git remote -v`)
+- `gh` is installed and authenticated (`gh auth status`)
+
+## What This Skill Adds
+
+- MIT `LICENSE`
+- `.github/workflows/ci.yml` — runs `uv run nox` on push and pull request
+- `.github/workflows/release.yml` — tag-triggered release and PyPI publish workflow
+- `cliff.toml` — changelog generation with Conventional Commits
+- CI and PyPI badges inserted into `README.md`
+- automated branch protection via `gh api`
+- PyPI Trusted Publisher manual checklist
+
+## OSS Hardening Flow
+
+### 1. Guards
+
+```bash
+git branch --show-current    # must NOT be main — stop if it is
+git rev-parse --show-toplevel  # must be a git repo
+```
+
+If on `main`: stop and tell the user to create a feature branch first with `/git feature oss-setup`, then rerun `/oss-setup`.
+
+Verify `pyproject.toml` exists. If not, stop — run `/python-init` first.
+
+### 2. Resolve Metadata
+
+```bash
+git config user.name          # author name
+date +%Y                      # current year
+gh repo view --json owner,name  # owner and repo name for badges and branch protection
+```
+
+Extract project name from `pyproject.toml` `[project] name`.
+
+### 3. Create LICENSE
+
+MIT license with resolved author and year:
+
+```
+MIT License
+
+Copyright (c) <year> <author>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### 4. Create `.github/workflows/ci.yml`
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv run nox
+```
+
+Job name is `check`. The branch protection status check string will be `CI / check`. Keep this consistent.
+
+### 5. Create `.github/workflows/release.yml`
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv run nox
+      - run: uv build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+```
+
+Requires PyPI Trusted Publisher to be configured (see manual checklist below). The `environment: release` matches the Trusted Publisher environment name.
+
+### 6. Create `cliff.toml`
+
+```toml
+[changelog]
+header = "# Changelog\n"
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | strtitle }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}\
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^test", group = "Testing" },
+  { message = "^chore", group = "Miscellaneous" },
+  { message = "^ci", group = "CI" },
+]
+filter_commits = false
+tag_pattern = "v[0-9].*"
+```
+
+### 7. Add README Badges
+
+If `README.md` exists, insert the two badge lines on the line directly below the first `#` heading — do not rewrite anything else.
+
+```markdown
+[![CI](https://github.com/{owner}/{repo}/actions/workflows/ci.yml/badge.svg)](https://github.com/{owner}/{repo}/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/{name})](https://pypi.org/project/{name}/)
+```
+
+Fill `{owner}` and `{repo}` from `gh repo view`. Fill `{name}` from `pyproject.toml` project name. Do not add placeholder values — only insert when all three are known.
+
+### 8. Verify
+
+```bash
+uv run nox
+```
+
+Must pass before committing. If anything fails, fix it before proceeding.
+
+### 9. Commit
+
+Stage all OSS setup files and commit:
+
+```bash
+git add LICENSE .github/ cliff.toml README.md
+git commit -m "feat(ci): add oss release tooling and workflows"
+```
+
+### 10. Apply Branch Protection
+
+```bash
+gh auth status   # confirm authenticated
+gh repo view --json owner,name   # resolve {owner} and {repo}
+```
+
+Apply branch protection via the GitHub API:
+
+```bash
+gh api repos/{owner}/{repo}/branches/main/protection \
+  --method PUT \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["CI / check"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+```
+
+Notes:
+- `enforce_admins: false` — intentional. Allows the repo owner to push the release commit directly to `main` without a PR. CI still runs on the tag push before PyPI publishes. For a solo OSS repo this is the right tradeoff — strict admin enforcement would block the `/release` flow.
+- `required_pull_request_reviews` is intentionally `null` — CI is the real gate, not mandatory PR reviews
+- `CI / check` is the status check string from the workflow (workflow name `CI`, job name `check`)
+- After the first CI run, verify this matches the name shown in GitHub → Settings → Branches → Edit rule. If it differs, update the protection rule with the correct string
+
+On success: confirm branch protection is active.
+
+On failure (not authenticated, API error): skip automation and include the manual branch protection steps in the final checklist.
+
+### 11. Report
+
+Tell the user:
+- what was created (LICENSE, workflows, cliff.toml, badges, branch protection status)
+- one manual step remains: PyPI Trusted Publisher setup
+- release flow: run `/release` from `main` after PRs are merged
+
+## Manual Follow-Up Checklist
+
+PyPI Trusted Publisher (must be done in the PyPI web UI — one-time per project):
+- Go to https://pypi.org/manage/account/publishing/
+- Add a new publisher with these exact values:
+  - Repository owner: `{owner}`
+  - Repository name: `{repo}`
+  - Workflow filename: `release.yml`
+  - Environment name: `release`  ← must match `environment: release` in the release workflow exactly
+
+If branch protection was not applied automatically:
+- Go to GitHub → Settings → Branches → Add rule for `main`
+- Enable: Require status checks to pass (`CI / check`)
+- Enable: Block force pushes
+- Leave PR reviews optional — CI is the gate
+- Leave "Include administrators" unchecked — this allows the repo owner to push release commits directly to `main`
+
+## Rules
+
+- Always run from a feature branch, never from `main`
+- Keep `nox` as the single CI entrypoint
+- One CI workflow, one release workflow — no overlapping workflows
+- Do not publish to PyPI from this command
+- Do not add badges with placeholder values
+- Do not rewrite the README — only insert the two badge lines
+- `CHANGELOG.md` is not created here — `/release` owns it on first release
+
+## Don't
+
+- Run on portfolio or tool repositories
+- Run from `main`
+- Create release ceremony for repos that do not publish to PyPI
+- Duplicate base Python setup that belongs in `python-setup`

--- a/.opencode/skills/python-setup/SKILL.md
+++ b/.opencode/skills/python-setup/SKILL.md
@@ -1,0 +1,479 @@
+---
+name: python-setup
+description: Bootstrap a Python OSS repository from PROJECT.md — production-quality setup with uv, ruff, pyright, pytest, pytest-cov, and nox, adapted to the specific project type
+---
+## Purpose
+
+Use this skill to initialize a new Python OSS project from `PROJECT.md`.
+
+Repository category: `oss` — public, publishable, reviewable. Full toolchain, proper packaging metadata, CI-ready validation from day one.
+
+This skill handles the base Python setup only. After it completes, run `/oss-setup` to add CI workflow, release workflow, changelog tooling, license, and badges.
+
+## PROJECT.md Format
+
+```markdown
+# [Project Name]
+
+## Identity
+- **What**: [1 sentence — what does the project do]
+- **Why**: [1 sentence — what problem does it solve]
+- **Type**: [cli | library | api | data-pipeline]
+- **Python**: 3.12
+
+## Architecture
+- **Framework**: [Click | Typer | FastAPI | plain | none]
+- **Dependencies**: [package: why, or "none"]
+- **Secrets**: [ENV_VAR_NAME: purpose, or "none"]
+
+## Objectives
+### MVP
+- [ ] [Concrete, testable goal]
+
+### Non-Goals
+- [What this does not do]
+
+## Setup
+- **Category**: oss
+- **Git Remote**: [https://github.com/user/repo]
+```
+
+Fields the skill reads:
+- `name` → package name (kebab-case display, snake_case for Python identifier)
+- `type` → directory structure
+- `python` → version to pin (default `3.12`)
+- `framework` → production framework dep
+- `dependencies` → additional production deps
+- `secrets` → `.env.example` variables
+- `git_remote` → remote URL (required for OSS — remote should exist before init)
+
+## Toolchain
+
+- `uv` — package and environment management
+- `ruff` — linting and formatting
+- `pyright` — type checking (always included)
+- `pytest` + `pytest-cov` — tests with coverage
+- `nox` — validation entrypoint with CI session
+
+## Bootstrap Process
+
+### 1. Read PROJECT.md
+
+Parse all fields. Stop immediately if `PROJECT.md` is missing. For OSS, `git_remote` should be set — warn if it is "local only" since the OSS workflow assumes a GitHub remote.
+
+### 2. Initialize uv
+
+```bash
+uv init
+uv python pin <python-version>
+```
+
+### 3. Create Package Structure
+
+Use `src/` layout for all types.
+
+**cli**
+```
+src/<package>/
+├── __init__.py
+├── __main__.py
+├── cli.py
+└── config.py
+tests/
+├── __init__.py
+└── test_cli.py
+```
+
+**library**
+```
+src/<package>/
+├── __init__.py
+├── core.py
+└── models.py
+tests/
+├── __init__.py
+└── test_core.py
+```
+
+**api**
+```
+src/<package>/
+├── __init__.py
+├── main.py
+├── routes/
+│   └── __init__.py
+├── models.py
+└── config.py
+tests/
+├── __init__.py
+└── test_main.py
+```
+
+**data-pipeline**
+```
+src/<package>/
+├── __init__.py
+├── pipeline.py
+├── models.py
+└── config.py
+tests/
+├── __init__.py
+└── test_pipeline.py
+data/               (.gitkeep)
+```
+
+### 4. Install Dependencies
+
+```bash
+uv add --dev ruff pyright pytest pytest-cov nox pip-audit
+```
+
+Framework deps:
+- Click → `uv add click`
+- Typer → `uv add typer`
+- FastAPI → `uv add fastapi uvicorn`
+
+Pydantic for types with config or data models:
+```bash
+uv add pydantic pydantic-settings
+```
+
+Any additional deps from PROJECT.md `dependencies`:
+```bash
+uv add <dep>
+```
+
+### 5. Generate pyproject.toml
+
+OSS repos include full public packaging metadata:
+
+```toml
+[project]
+name = "<project-name>"
+version = "0.1.0"
+description = "<Identity.What from PROJECT.md>"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.12"
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/<user>/<repo>"
+Repository = "https://github.com/<user>/<repo>"
+
+[dependency-groups]
+dev = [
+  "nox",
+  "pyright",
+  "pytest",
+  "pytest-cov",
+  "ruff",
+  "pip-audit",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "S"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S101", "S105", "S106", "S108", "S113"]
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+include = ["src", "tests"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"
+```
+
+Fill `name`, `description`, `requires-python`, and URL fields from PROJECT.md and `git_remote`. Production deps go into `dependencies` after `uv add`.
+
+### 6. Generate noxfile.py
+
+OSS repos include a `ci` session for the GitHub Actions gate and a `security` session for dependency auditing:
+
+```python
+import nox
+
+
+nox.options.sessions = ["lint", "typecheck", "test", "security"]
+
+
+@nox.session
+def lint(session: nox.Session) -> None:
+    session.run("uv", "run", "ruff", "check", "src", "tests")
+
+
+@nox.session
+def format(session: nox.Session) -> None:
+    session.run("uv", "run", "ruff", "format", "src", "tests")
+
+
+@nox.session
+def fix(session: nox.Session) -> None:
+    session.run("uv", "run", "ruff", "check", "--fix", "src", "tests")
+    session.run("uv", "run", "ruff", "format", "src", "tests")
+
+
+@nox.session
+def typecheck(session: nox.Session) -> None:
+    session.run("uv", "run", "pyright", "src")
+
+
+@nox.session
+def test(session: nox.Session) -> None:
+    session.run("uv", "run", "pytest", "-v")
+
+
+@nox.session
+def coverage(session: nox.Session) -> None:
+    session.run(
+        "uv", "run", "pytest",
+        "--cov=src", "--cov-report=term", "--cov-report=html",
+    )
+
+
+@nox.session
+def ci(session: nox.Session) -> None:
+    session.run("uv", "run", "ruff", "check", "src", "tests")
+    session.run("uv", "run", "ruff", "format", "--check", "src", "tests")
+    session.run("uv", "run", "pyright", "src")
+    session.run("uv", "run", "pytest", "-v")
+
+
+@nox.session
+def security(session: nox.Session) -> None:
+    """Security audit: dependency vulnerabilities + SAST."""
+    session.install("pip-audit")
+    session.run("uv", "run", "pip-audit", "--skip-editable")
+    session.run("uv", "run", "ruff", "check", "--select", "S", "src", "tests")
+```
+
+### 7. Generate .gitignore
+
+Generate based on tools in use. Always include:
+```
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.pytest_cache/
+.ruff_cache/
+.pyright/
+.nox/
+.coverage
+htmlcov/
+build/
+dist/
+*.egg-info/
+```
+
+Add `.env` if secrets are configured in PROJECT.md.
+Nothing else — OSS repos should not have project-specific noise in `.gitignore`.
+
+### 8. Generate .env.example
+
+Only if `secrets` is defined in PROJECT.md:
+```
+# ENV_VAR_NAME: purpose
+ENV_VAR_NAME=
+```
+
+Skip entirely if secrets is "none".
+
+### 9. Generate README.md
+
+OSS README should be presentable from day one:
+
+```markdown
+# <project-name>
+
+> <Identity.What from PROJECT.md>
+
+<Identity.Why — what problem this solves>
+
+## Installation
+
+\`\`\`bash
+pip install <project-name>
+\`\`\`
+
+## Usage
+
+<usage example based on project type>
+
+## Development
+
+\`\`\`bash
+uv sync
+uv run nox -s fix        # lint and format
+uv run nox -s test       # run tests
+uv run nox               # full validation
+\`\`\`
+
+## License
+
+MIT
+```
+
+### 10. Fill AGENTS.md
+
+The `AGENTS.md` template is already present in the project root — it was copied from the OSS template. Fill in the placeholders from PROJECT.md:
+
+- Replace `<Project Name>` with the project name
+- Replace the description placeholder with `Identity.What` and `Identity.Why` from PROJECT.md
+- Replace `<version>` in Tech Stack with the Python version
+- Add the framework to Tech Stack if one is configured
+- Replace `<type>` in Project Type with the actual project type
+- Fill in the Structure section with the actual `src/<package>/` directory name
+- Add any project-specific conventions from PROJECT.md
+
+Leave `## Known Constraints` empty — it gets filled over time.
+
+### 11. Write Starter Files
+
+`src/<package>/__init__.py`:
+```python
+"""<Identity.What from PROJECT.md>."""
+
+__version__ = "0.1.0"
+```
+
+Entrypoint by type:
+
+**cli** — `src/<package>/cli.py`:
+```python
+"""<package> CLI."""
+
+import typer
+
+app = typer.Typer()
+
+
+@app.command()
+def main() -> None:
+    """<brief description>."""
+    pass
+```
+
+**api** — `src/<package>/main.py`:
+```python
+"""<package> API."""
+
+from fastapi import FastAPI
+
+app = FastAPI(title="<project-name>")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Health check."""
+    return {"status": "ok"}
+```
+
+**data-pipeline** — `src/<package>/pipeline.py`:
+```python
+"""<package> pipeline."""
+
+
+def run() -> None:
+    """Run the pipeline."""
+    pass
+```
+
+**library** — `src/<package>/core.py`:
+```python
+"""<package> core."""
+```
+
+Smoke test — `tests/test_<package>.py`:
+```python
+"""Smoke tests."""
+
+
+def test_import() -> None:
+    import <package>
+    assert <package>.__version__ == "0.1.0"
+```
+
+### 12. Initialize Git
+
+Check whether `.git` already exists:
+
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null
+```
+
+**If `.git` already exists** (repo was cloned from GitHub):
+- skip `git init`
+- check if remote `origin` is already set: `git remote -v`
+- if remote is not set and `git_remote` is in PROJECT.md, add it: `git remote add origin <url>`
+- stage and commit: `git add . && git commit -m "chore: initial project setup"`
+- push: `git push -u origin main`
+
+**If `.git` does not exist** (fresh directory):
+```bash
+git init
+git add .
+git commit -m "chore: initial project setup"
+```
+If `git_remote` is configured in PROJECT.md:
+```bash
+git remote add origin <url>
+git push -u origin main
+```
+
+If push fails: stop and report init is incomplete — the OSS workflow requires a working remote. Likely causes: remote repo does not exist yet, wrong URL, auth issue.
+
+### 13. Verify
+
+```bash
+OPENCODE_CONFIG=./opencode.json opencode --help >/dev/null
+uv sync
+uv run nox
+```
+
+Both checks must be green. Fix any failures before declaring success.
+
+### 14. Summary
+
+Report:
+- project name, type, Python version, tools installed
+- git status: committed on main; remote push result
+- nox result
+
+Tell the user explicitly:
+```
+Next steps for OSS setup:
+1. Run /git feature oss-setup   ← create a feature branch first
+2. Run /oss-setup               ← apply CI, release workflow, license, branch protection
+3. Run /git pr                  ← open a PR
+4. Merge in GitHub UI
+```
+
+Do not say "run /oss-setup" without the branch step — /oss-setup requires being on a feature branch, not main.
+
+## Guiding principles
+
+Scaffold only — the purpose of init is a working skeleton, not a product. Implementing business logic from PROJECT.md at this stage conflates setup with delivery and makes the scaffold harder to verify.
+
+Create `AGENTS.md` — it's the persistent context file every agent reads at the start of every session. Without it the project has no local context and the agent has to rediscover conventions every time.
+
+Create at least one passing smoke test — a scaffold that doesn't run a test can't prove `nox` works end-to-end. Even a trivial import test gives confidence the structure is correct.
+
+Use `src/` layout — it prevents the common Python mistake of accidentally importing from the project root rather than the installed package, which causes subtle bugs in testing.
+
+Use `uv add` rather than editing `pyproject.toml` directly — uv resolves and locks dependencies correctly; hand-editing can produce inconsistent lock state.
+
+Don't create `CHANGELOG.md` — changelogs are release history. Creating one at init time is premature and `/release` will generate it correctly from git history on the first release.
+
+Don't add deps beyond what PROJECT.md specifies — over-installing during scaffold makes it harder to understand what the project actually needs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,14 @@
 ## Overview
 Python CLI that renames local files from AI-extracted metadata.
 
+## Repository Category
+
+`oss` - public, publishable, reviewable.
+
+- always work on a feature branch, never directly on `main`
+- conventional commits, PR flow, squash merge in GitHub UI
+- keep README, packaging metadata, and release hygiene public-facing and intentional
+
 ## Tech Stack
 - Language: Python 3.12+
 - Framework: Typer
@@ -19,6 +27,14 @@ tests/
 docs/
 ├── decisions/        # Architecture notes if needed later
 ```
+
+## Validation
+
+- `uv run nox` - full validation gate; run before every commit
+- `nox -s lint` - docs, config, comment-only changes
+- `nox -s lint typecheck` - structural changes (new modules, imports, type signatures)
+- `nox -s lint typecheck test` - logic or behavior changes
+- `nox -s ci` - CI-equivalent local check
 
 ## Code Quality
 
@@ -51,6 +67,11 @@ Use Google-style docstrings for public modules, functions, and classes.
 - Keep the implementation simple and sync-first.
 - Keep config flat and explicit.
 - Prefer small focused helpers over framework-style abstractions.
+
+## Library Documentation
+
+Context7 MCP is available in this project. When working with external libraries, prefer
+version-specific docs from Context7 instead of relying on memory.
 
 ## Architecture Decisions
 - Use src/ layout for packaging.

--- a/README.md
+++ b/README.md
@@ -100,9 +100,12 @@ dpi = 150
 jpeg_quality = 80
 
 [logging]
-level = "INFO"
+level = "WARNING"
 json_logs = false
 ```
+
+Set `logging.level = "WARNING"` to keep routine CLI output quiet. Use `renamr run --verbose`
+only when you want debug logging for troubleshooting.
 
 `inbox_paths` accepts one or more folders. `renamr run` processes all of them in one pass.
 Use `--inbox /some/folder` for a one-off override without editing the config.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "watcher": {
+    "ignore": [
+      ".venv/**",
+      ".nox/**",
+      ".pytest_cache/**",
+      ".ruff_cache/**",
+      ".pyright/**",
+      "build/**",
+      "dist/**",
+      "htmlcov/**",
+      "*.egg-info/**"
+    ]
+  },
+  "mcp": {
+    "context7": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "@upstash/context7-mcp"
+      ],
+      "environment": {
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pillow>=12.1.1",
     "pydantic>=2.12.5",
     "pymupdf>=1.27.2",
-    "pypdf>=6.8.0",
+    "pypdf>=6.9.1",
     "structlog>=25.5.0",
     "typer>=0.24.1",
 ]

--- a/src/renamr/cli.py
+++ b/src/renamr/cli.py
@@ -43,7 +43,7 @@ def init(
     config: Annotated[Path | None, typer.Option("--config")] = None,
 ) -> None:
     """Create a local config file and data directory."""
-    setup_logging("INFO", False)
+    setup_logging("WARNING", False)
     config_path = config or _config_dir() / "config.toml"
     if config_path.exists():
         typer.echo(f"{config_path} already exists. Delete it to reinitialize.")
@@ -103,7 +103,7 @@ def undo(
     config: Annotated[Path | None, typer.Option("--config")] = None,
 ) -> None:
     """Undo the last successful rename run."""
-    setup_logging("INFO", False)
+    setup_logging("WARNING", False)
     config_path = config or _config_dir() / "config.toml"
     data_dir = config_path.parent
     reversed_pairs = undo_last_run(data_dir)

--- a/src/renamr/config.toml.example
+++ b/src/renamr/config.toml.example
@@ -20,5 +20,5 @@ dpi = 150
 jpeg_quality = 80
 
 [logging]
-level = "INFO"
+level = "WARNING"
 json_logs = false

--- a/src/renamr/logging.py
+++ b/src/renamr/logging.py
@@ -4,9 +4,12 @@ import logging
 
 import structlog
 
+NOISY_DEPENDENCY_LOGGERS = ("httpx", "httpcore", "litellm", "openai")
+
 
 def setup_logging(level: str, json_logs: bool) -> None:
     """Configure stdlib logging and structlog."""
+    log_level = getattr(logging, level.upper(), logging.WARNING)
     processors = [
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.stdlib.add_log_level,
@@ -19,10 +22,12 @@ def setup_logging(level: str, json_logs: bool) -> None:
         else structlog.dev.ConsoleRenderer(colors=False)
     )
     logging.basicConfig(
-        level=getattr(logging, level.upper(), logging.INFO),
+        level=logging.WARNING,
         format="%(message)s",
         force=True,
     )
+    logging.getLogger("renamr").setLevel(log_level)
+    _configure_dependency_loggers()
     structlog.configure(
         processors=[
             structlog.stdlib.filter_by_level,
@@ -33,3 +38,12 @@ def setup_logging(level: str, json_logs: bool) -> None:
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,
     )
+
+
+def _configure_dependency_loggers() -> None:
+    """Keep noisy dependency loggers quiet and routed through root only."""
+    for logger_name in NOISY_DEPENDENCY_LOGGERS:
+        logger = logging.getLogger(logger_name)
+        logger.handlers.clear()
+        logger.setLevel(logging.WARNING)
+        logger.propagate = True

--- a/src/renamr/models.py
+++ b/src/renamr/models.py
@@ -93,7 +93,7 @@ Example C - Scanned image, no readable date:
 class LoggingConfig(BaseModel):
     """Logging-related configuration."""
 
-    level: str = Field(default="INFO")
+    level: str = Field(default="WARNING")
     json_logs: bool = Field(default=False)
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -17,3 +17,10 @@ def test_filename_template_accepts_supported_placeholders() -> None:
 def test_filename_template_rejects_unknown_placeholders() -> None:
     with pytest.raises(ValidationError, match="unknown placeholder: project"):
         AppConfig(filename_template="{date}_{project}")
+
+
+def test_logging_defaults_to_warning_and_plain_text() -> None:
+    config = AppConfig()
+
+    assert config.logging.level == "WARNING"
+    assert config.logging.json_logs is False

--- a/uv.lock
+++ b/uv.lock
@@ -1492,11 +1492,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.8.0"
+version = "6.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b4/a3/e705b0805212b663a4c27b861c8a603dba0f8b4bb281f96f8e746576a50d/pypdf-6.8.0.tar.gz", hash = "sha256:cb7eaeaa4133ce76f762184069a854e03f4d9a08568f0e0623f7ea810407833b", size = 5307831, upload-time = "2026-03-09T13:37:40.591Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/fb/dc2e8cb006e80b0020ed20d8649106fe4274e82d8e756ad3e24ade19c0df/pypdf-6.9.1.tar.gz", hash = "sha256:ae052407d33d34de0c86c5c729be6d51010bf36e03035a8f23ab449bca52377d", size = 5311551, upload-time = "2026-03-17T10:46:07.876Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/ec/4ccf3bb86b1afe5d7176e1c8abcdbf22b53dd682ec2eda50e1caadcf6846/pypdf-6.8.0-py3-none-any.whl", hash = "sha256:2a025080a8dd73f48123c89c57174a5ff3806c71763ee4e49572dc90454943c7", size = 332177, upload-time = "2026-03-09T13:37:38.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f4/75543fa802b86e72f87e9395440fe1a89a6d149887e3e55745715c3352ac/pypdf-6.9.1-py3-none-any.whl", hash = "sha256:f35a6a022348fae47e092a908339a8f3dc993510c026bb39a96718fc7185e89f", size = 333661, upload-time = "2026-03-17T10:46:06.286Z" },
 ]
 
 [[package]]
@@ -1742,7 +1742,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pymupdf", specifier = ">=1.27.2" },
-    { name = "pypdf", specifier = ">=6.8.0" },
+    { name = "pypdf", specifier = ">=6.9.1" },
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "typer", specifier = ">=0.24.1" },
 ]


### PR DESCRIPTION
## Summary
- add the missing OpenCode project scaffolding for this OSS Python repo, including `opencode.json`, local commands, local skills, and project lessons
- align `AGENTS.md` with the standard OpenCode OSS workflow while preserving the existing project-specific conventions and constraints
- remove stale `.pi` ignore entries now that the repo uses the OpenCode layout

## Validation
- OPENCODE_CONFIG=./opencode.json opencode --help >/dev/null
- uv run nox